### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,18 @@
 # IbaDatFile
+IbaDatFile is a Pythonic wrapper for interacting with iba dat files through the Iba ```ibaFilesLite.dll```. This package simplifies access to the Iba dat file format, making it easier to work with the data in Python.
 
-Pythonic wrapper for the .iba dat file dll
+## Requirements
+- Windows-only: This package is designed to work on Windows systems.
+- 32-bit Python: The Iba ```IbaFiles.dll``` is a 32-bit COM object. Therefore, a 32-bit version of Python is required to ensure compatibility.
+- Iba ```ibaFilesLite.dll```: You must have the Iba ```ibaFilesLite.dll``` installed and registered on your system.
 
 ## Getting Started
+### Register Iba ```ibaFilesLite.dll```
+Make sure the Iba ```ibaFilesLite.dll``` is properly registered on your system. You can do this by running the following command when you are in the directory through Command Prompt:
 
-This package needs to have the Iba IbaFiles.dll installed (Windows-only)
+
+Copy code
+
+```
+regsvr32 path\to\ibaFilesLite.dll
+```

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ IbaDatFile is a Pythonic wrapper for interacting with iba dat files through the 
 
 ## Requirements
 - Windows-only: This package is designed to work on Windows systems.
-- 32-bit Python: The Iba ```IbaFiles.dll``` is a 32-bit COM object. Therefore, a 32-bit version of Python is required to ensure compatibility.
+- In Python, the ```IbaFilesLite.dll``` COM object can be either 32-bit or 64-bit. To ensure compatibility, you must verify that the architecture of ```IbaFilesLite.dll``` matches your Python installation. For instance, if you're using a 32-bit ```IbaFilesLite.dll```, you need to run a 32-bit version of Python.
 - Iba ```ibaFilesLite.dll```: You must have the Iba ```ibaFilesLite.dll``` installed and registered on your system.
 
 ## Getting Started


### PR DESCRIPTION
I have updated the README to include important details about the requirement for a 32-bit version of Python due to the 32-bit nature of the Iba IbaFiles.dll. This update also provides a small guide to help with compatibility and smooth operation of the IbaDatFile wrapper on Windows systems.